### PR TITLE
Import standard C++ libraries before Arduino ones

### DIFF
--- a/SimpleTimer.h
+++ b/SimpleTimer.h
@@ -28,13 +28,13 @@
 #ifndef SIMPLETIMER_H
 #define SIMPLETIMER_H
 
+#include <functional>
+
 #if defined(ARDUINO) && ARDUINO >= 100
 #include <Arduino.h>
 #else
 #include <WProgram.h>
 #endif
-
-#include <functional>
 
 typedef std::function<void(void)> timer_callback;
 


### PR DESCRIPTION
The `Arduino.h` header defines `min` and `max` macros which can cause compiler errors if it's included before standard C++ libraries since those also have macros for `min` and `max` and they have different number of parameters. 