### PR TITLE
Change interval to unsigned type

### DIFF
--- a/SimpleTimer.cpp
+++ b/SimpleTimer.cpp
@@ -131,7 +131,7 @@ int SimpleTimer::findFirstFreeSlot() {
 }
 
 
-int SimpleTimer::setTimer(long d, timer_callback f, int n) {
+int SimpleTimer::setTimer(unsigned long d, timer_callback f, int n) {
     int freeTimer;
 
     freeTimer = findFirstFreeSlot();
@@ -155,12 +155,12 @@ int SimpleTimer::setTimer(long d, timer_callback f, int n) {
 }
 
 
-int SimpleTimer::setInterval(long d, timer_callback f) {
+int SimpleTimer::setInterval(unsigned long d, timer_callback f) {
     return setTimer(d, f, RUN_FOREVER);
 }
 
 
-int SimpleTimer::setTimeout(long d, timer_callback f) {
+int SimpleTimer::setTimeout(unsigned long d, timer_callback f) {
     return setTimer(d, f, RUN_ONCE);
 }
 

--- a/SimpleTimer.h
+++ b/SimpleTimer.h
@@ -61,13 +61,13 @@ public:
     void run();
 
     // call function f every d milliseconds
-    int setInterval(long d, timer_callback f);
+    int setInterval(unsigned long d, timer_callback f);
 
     // call function f once after d milliseconds
-    int setTimeout(long d, timer_callback f);
+    int setTimeout(unsigned long d, timer_callback f);
 
     // call function f every d milliseconds for n times
-    int setTimer(long d, timer_callback f, int n);
+    int setTimer(unsigned long d, timer_callback f, int n);
 
     // destroy the specified timer
     void deleteTimer(int numTimer);
@@ -111,7 +111,7 @@ private:
     timer_callback callbacks[MAX_TIMERS];
 
     // delay values
-    long delays[MAX_TIMERS];
+    unsigned long delays[MAX_TIMERS];
 
     // number of runs to be executed for each timer
     int maxNumRuns[MAX_TIMERS];


### PR DESCRIPTION
The interval can not be negative, so should be unsigned. 

In https://github.com/schinken/SimpleTimer/blob/172e37fe62b06745f7652713b3a760cf362d252c/SimpleTimer.cpp#L66 the unsigned `current_millis` and `prev-millis` are compared with the signed `delays`, and this results in an compiler warning (SimpleTimer.cpp:66:49: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]). This PR fixes the warning.